### PR TITLE
Fix a minor bug in the playground app, resulting in 404's in some cases.

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -133,6 +133,8 @@ $('document').ready(function () {
     for (var i = 0; i < vars.length; i++) {
       param = vars[i].split('=');
       if (param[0] === 'example') {
+        if (param[1].charAt(param[1].length - 1) == '/') 
+          return param[1].replace('/', '');
         return param[1];
       }
     }


### PR DESCRIPTION
> For some reason, the browser keeps appending a trailing '/' at the end
> of the URLs. Since the loadExample function in playground.js parses the
> request parameter itself and uses it to load the JSON, a trailing '/' at
> the end of the URL causes the function to generate a request for a JSON
> named '.json'.
> 
> The PR adds a check for a trailing '/' and taking appropriate action if
> there is a trailing slash.
