### PR TITLE
Handle more than one type.

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -3082,6 +3082,19 @@ formTree.prototype.buildFromLayout = function (formElement, context) {
     // If the form element does not define its type, use the type of
     // the schema element.
     if (!formElement.type) {
+      // If schema type is an array containing only a type and "null",
+      // remove null and make the element non-required
+      if (_.isArray(schemaElement.type)) {
+        if (_.contains(schemaElement.type, "null")) {
+          schemaElement.type = _.without(schemaElement.type, "null");
+          schemaElement.required = false;
+        }
+        if (schemaElement.type.length > 1) {
+          throw new Error("Cannot process schema element with multiple types.");
+        }
+        schemaElement.type = _.first(schemaElement.type);
+      }
+
       if ((schemaElement.type === 'string') &&
         (schemaElement.format === 'color')) {
         formElement.type = 'color';


### PR DESCRIPTION
> If jsonform encounters a form element with more than one type, first
> tries to remove null and set as not required, then throws an error if
> there's still more than one type. Compatible with Json.NET Schema
> Generator.
